### PR TITLE
Add Nix flake

### DIFF
--- a/elfeed-offline.nix
+++ b/elfeed-offline.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildDunePackage,
+  dream,
+  cmdliner,
+  cohttp,
+  cohttp-lwt-unix,
+  lwt,
+  brr,
+  uri,
+  uri-sexp,
+  ptime,
+  astring,
+  lwd,
+  brr-lwd,
+  alcotest,
+  syndic,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "elfeed-offline";
+  version = "0.0.1";
+
+  src = with lib.fileset; toSource {
+    root = ./.;
+    fileset = gitTracked ./.;
+  };
+
+  propagatedBuildInputs = [
+    dream
+    cmdliner
+    cohttp
+    cohttp-lwt-unix
+    lwt
+    brr
+    uri
+    uri-sexp
+    ptime
+    astring
+    lwd
+    brr-lwd
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    alcotest
+    syndic
+  ];
+
+  meta = {
+    homepage = "https://github.com/punchagan/elfeed-offline";
+    description = "Offline reading web interface for the Emacs RSS client Elfeed";
+    license = lib.licenses.agpl3Only;
+  };
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774273680,
+        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,88 @@
+{
+  description = "";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (final: prev: {
+              ocamlPackages = prev.ocamlPackages.overrideScope (ocamlFinal: ocamlPrev: {
+                uri = ocamlPrev.uri.overrideAttrs (prev': {
+                  patches = (prev.patches or []) ++ [
+                    (final.fetchpatch {
+                      url = "https://github.com/punchagan/ocaml-uri/commit/ba6c3e6c36cfaece956190be9469f894f56d3124.patch";
+                      hash = "sha256-LbyrC2npmB1jDUG4okM/hpA5+eNQv+PuExhbFK9gxF8=";
+                    })
+                  ];
+                });
+              });
+            })
+          ];
+        };
+      in
+      {
+        packages = rec {
+          syndic = with pkgs; with ocamlPackages; buildDunePackage (finalAttrs: {
+            pname = "syndic";
+            version = "1.8.0";
+
+            src = fetchFromGitHub {
+              owner = "Cumulus";
+              repo = "Syndic";
+              rev = "v${finalAttrs.version}";
+              hash = "sha256-UQ7EN+pvRjZ3qcdMilUBTuRMehe0ElyIPmqXmB7VN6o=";
+            };
+
+            propagatedBuildInputs = [
+              ptime
+              xmlm
+              uri
+            ];
+
+            meta = {
+              homepage = "https://github.com/Cumulus/Syndic";
+              description = "RSS and Atom feed parsing";
+              license = lib.licenses.mit;
+            };
+          });
+          brr-lwd = with pkgs; with ocamlPackages; buildDunePackage (finalAttrs: {
+            pname = "brr-lwd";
+            inherit (lwd) version src;
+
+            propagatedBuildInputs = [
+              lwd
+              brr
+            ];
+
+            meta = {
+              description = "Make reactive webpages in Js_of_ocaml using Brr and Lwd";
+              license = lib.licenses.mit;
+              homepage = "https://github.com/let-def/lwd";
+            };
+          });
+
+          elfeed-offline = pkgs.ocamlPackages.callPackage ./elfeed-offline.nix { inherit syndic brr-lwd; };
+          default = elfeed-offline;
+        };
+
+        devShells.default = with pkgs; mkShell {
+          packages = [
+            pkg-config
+            openssl
+            gmp
+            libev
+            mkcert
+            nss
+            dune
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Now that Dune 3.21 has landed in nixpkgs, I thought it would be nice to make it even easier for people to try this excellent package using e.g. `nix run github:punchagan/elfeed-offline -- --no-auth`.